### PR TITLE
Dirty fix: room_lts_id can be an empty XML element

### DIFF
--- a/MssNet/Models/Response.cs
+++ b/MssNet/Models/Response.cs
@@ -409,7 +409,7 @@ namespace MssNet.Models.Response
         public int RoomId { get; set; }
 
         [XmlElement(ElementName = "room_lts_id")]
-        public int RoomLtsId { get; set; }
+        public string RoomLtsId { get; set; }
 
         [XmlElement(ElementName = "room_numbers")]
         public string[] RoomNumbers { get; set; }


### PR DESCRIPTION
When I run the unit test `MssNet.Tests.MssClientTest.SendRequest_GivenValidRequest_ShouldReturnResponse` it uses the following sample XML response:

```xml
<root>
   <header>
      <error>
         <code>0</code>
         <message>OK</message>
      </error>
      <result_id>e2b34c8ba3291facf86dcdee69dcd986</result_id>
      <source>hgv_crm</source>
      <paging>
         <count>1</count>
         <total>1</total>
      </paging>
      <time>61.02 ms</time>
   </header>
   <result>
      <hotel>
         <id>9002</id>
         <id_lts />
         <bookable>1</bookable>
         <channel>
            <channel_id>hgv</channel_id>
            <room_description>
               <room>
                  <room_id>25722</room_id>
                  <room_type>1</room_type>
                  <room_code>testzimm</room_code>
                  <room_lts_id />
               </room>
               <room>
                  <room_id>25723</room_id>
                  <room_type>1</room_type>
                  <room_code>EZK</room_code>
                  <room_lts_id />
               </room>
               <room>
                  <room_id>25724</room_id>
                  <room_type>1</room_type>
                  <room_code>DZ</room_code>
                  <room_lts_id />
               </room>
               <room>
                  <room_id>25725</room_id>
                  <room_type>1</room_type>
                  <room_code>DBZ</room_code>
                  <room_lts_id />
               </room>
            </room_description>
         </channel>
      </hotel>
   </result>
   <debug />
</root>
```

The deserialization fails, because `room_lts_id` is expected to be an integer.
My quick and dirty fix is to make it a string so it doesn't fail to deserialize.
Another solution is to update the sample XML if `room_lts_id` is never empty in the live XML.