### PR TITLE
Use parameter argument

### DIFF
--- a/MssNet.Tests/XmlDeserializerTest.cs
+++ b/MssNet.Tests/XmlDeserializerTest.cs
@@ -12,7 +12,7 @@ namespace MssNet.Tests
             var deserializer = new XmlDeserializer();
             var exception = Assert.Throws<ArgumentException>(() => deserializer.Deserialize<Person>(null));
 
-            Assert.Equal("xmlContent cannot be null or whitespace.", exception.Message);
+            Assert.Equal("xmlContent", exception.ParamName);
         }
 
         [Fact]
@@ -21,7 +21,7 @@ namespace MssNet.Tests
             var deserializer = new XmlDeserializer();
             var exception = Assert.Throws<ArgumentException>(() => deserializer.Deserialize<Person>(""));
 
-            Assert.Equal("xmlContent cannot be null or whitespace.", exception.Message);
+            Assert.Equal("xmlContent", exception.ParamName);
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace MssNet.Tests
             var deserializer = new XmlDeserializer();
             var exception = Assert.Throws<ArgumentException>(() => deserializer.Deserialize<Person>(" "));
 
-            Assert.Equal("xmlContent cannot be null or whitespace.", exception.Message);
+            Assert.Equal("xmlContent", exception.ParamName);
         }
 
         [Fact]

--- a/MssNet/Xml/XmlDeserializer.cs
+++ b/MssNet/Xml/XmlDeserializer.cs
@@ -8,7 +8,7 @@ namespace MssNet.Xml
         public T Deserialize<T>(string xmlContent)
         {
             if (string.IsNullOrWhiteSpace(xmlContent))
-                throw new ArgumentException($"{nameof(xmlContent)} cannot be null or whitespace.");
+                throw new ArgumentException("Cannot be null or whitespace.", nameof(xmlContent));
 
             using (TextReader reader = new StringReader(xmlContent))
             {


### PR DESCRIPTION
This change is purely cosmetic, but it is a [good practice](https://docs.microsoft.com/en-us/dotnet/api/system.argumentexception.-ctor?view=netcore-3.1#System_ArgumentException__ctor_System_String_System_String_) and allows to test for the parameter name instead of the string message.